### PR TITLE
fix(vercel): supprime la redirection avec pattern non supporté

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,6 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "redirects": [
-    {
-      "source": "/(?!fr/|en/).*",
-      "destination": "/fr/$1",
-      "permanent": true
-    }
-  ],
   "trailingSlash": true,
   "cleanUrls": false,
   "headers": [


### PR DESCRIPTION
Supprime la section redirects du vercel.json pour corriger l’erreur invalid route source pattern et garantir la compatibilité du déploiement.